### PR TITLE
change path of listing back button for better ux

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -78,7 +78,7 @@ class OffersController < ApplicationController
     authorize @offer
     if messages.length.positive?
       respond_to do |format|
-        format.json { render json: { header: 'no default msg' } }
+        format.json { render json: { header: 'no default msg' }, status: :ok }
       end
     else
       @offering_options = OfferingOption.where(offer: @offer)
@@ -91,7 +91,7 @@ class OffersController < ApplicationController
       @default_message.user = current_user
       if @default_message.save
         respond_to do |format|
-          format.json { render json: { header: 'default msg created' } }
+          format.json { render json: { header: 'default msg created' }, status: :ok }
         end
       else
         flash[:alert] = "Error generating default message"

--- a/app/views/plants/listing.html.erb
+++ b/app/views/plants/listing.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= link_to listings_plants_path do %>
+  <%= link_to :back do %>
     <i class="back-button-fixed fa-solid fa-angles-left"></i>
   <% end %>
 


### PR DESCRIPTION
- problem: after viewing lister plant in chat, always jumps back to marketplace home page
- should jump back to chat page
- problem solved by changing link_to path to :back